### PR TITLE
chore(OMN-12458): add onex-managed gitignore blocks for universal and python patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,32 @@ Thumbs.db
 .vscode/
 *.swp
 *.swo
+
+# === onex-managed: universal ===
+.env
+.env.*
+!.env.example
+.DS_Store
+*.log
+.idea/
+.vscode/
+test-results/
+playwright-report/
+# === end onex-managed: universal ===
+
+# === onex-managed: python ===
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/
+venv/
+env/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+# === end onex-managed: python ===


### PR DESCRIPTION
## Summary

- Appends two managed blocks to `.gitignore` for omnibase (public distribution repo)
- `onex-managed: universal` — covers `.env.*`, `.DS_Store`, `*.log`, IDE dirs, `test-results/`, `playwright-report/`
- `onex-managed: python` — covers `__pycache__/`, `*.py[cod]`, `.venv/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, `dist/`, `build/`, `*.egg-info/`
- No tracked `.pyc` files found; no `git rm --cached` required
- Existing lines preserved; blocks appended verbatim at end of file

## Ticket

OMN-12458 (epic OMN-12450)

## Test plan

- [ ] Verify `.gitignore` contains both managed blocks verbatim
- [ ] Confirm no `.pyc` or `__pycache__` entries appear in `git status` after creating Python cache files
- [ ] CI passes (no workflows configured for this distribution repo)