### PR TITLE
docs(OMN-13172): refresh omnibase documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Repositories are defined in `repos.yaml` and cloned into `repos/` by the install
 | `repos/omnibase_spi/` | Service provider interface protocols |
 | `repos/omnibase_compat/` | Shared structural package for cross-repo enums, wire DTOs, event envelopes |
 | `repos/omniclaude/` | Claude Code agent plugin — hooks, skills, agents |
-| `repos/omnidash/` | Next.js analytics and observability dashboard |
+| `repos/omnidash/` | Composable widget dashboard (Vite + React) |
 | `repos/omniintelligence/` | Intelligence nodes: intent classification, drift detection, review |
 | `repos/omnimemory/` | Document ingestion and semantic retrieval (RAG) |
 | `repos/omninode_infra/` | API service, k8s manifests, Terraform |
@@ -97,7 +97,7 @@ Redpanda (Kafka-compatible) handles all inter-node communication. Nodes subscrib
 # Install everything (clone repos, build envs, install deps)
 make install
 
-# Set up environment and start Docker infrastructure
+# Create .env from template (does NOT start Docker — run infra-up from repos/omnibase_infra for that)
 make setup
 
 # Start development servers
@@ -112,9 +112,9 @@ make update
 # Show repo versions and infrastructure health
 make status
 
-# Start/stop Docker infrastructure
-make docker-up
-make docker-down
+# Start/stop Docker infrastructure (run from repos/omnibase_infra)
+cd repos/omnibase_infra && infra-up
+cd repos/omnibase_infra && infra-down
 ```
 
 ### Per-Repo Commands
@@ -136,7 +136,7 @@ cd repos/omnibase_core && uv run onex --help
 
 ## Infrastructure
 
-The platform runs on Docker infrastructure started via `make docker-up`:
+The platform runs on Docker infrastructure managed by `omnibase_infra`. Start it with `cd repos/omnibase_infra && infra-up`:
 
 | Service | External Port (Host) | Internal Port (Docker) | Purpose |
 |---------|---------------------|----------------------|---------|

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cd omnibase
 make install
 ```
 
-This clones all ONEX repositories, builds Python environments, starts Docker infrastructure, and makes the `onex` CLI available.
+This clones all ONEX repositories, builds Python environments, installs dependencies, and makes the `onex` CLI available.
 
 ## What's Included
 
@@ -20,7 +20,7 @@ This clones all ONEX repositories, builds Python environments, starts Docker inf
 | omnibase_infra | Infrastructure services, Kafka, Postgres |
 | omnibase_spi | Service provider interface protocols |
 | omniclaude | Claude Code agent plugin, hooks, skills |
-| omnidash | Next.js analytics dashboard |
+| omnidash | Composable widget dashboard (Vite + React) |
 | omniintelligence | Intelligence nodes: intent, drift, review |
 | omnimemory | Document ingestion + semantic retrieval |
 | onex_change_control | Drift detection + governance |
@@ -40,7 +40,7 @@ This clones all ONEX repositories, builds Python environments, starts Docker inf
 # Install everything (clone repos, build envs, install deps)
 make install
 
-# Set up environment and start Docker infrastructure
+# Create .env from template (does NOT start Docker)
 make setup
 
 # Start development servers
@@ -54,10 +54,12 @@ make update
 
 # Show repo versions and infrastructure health
 make status
+```
 
-# Start/stop Docker infrastructure
-make docker-up
-make docker-down
+To start Docker infrastructure (PostgreSQL, Redpanda, Valkey), run from `repos/omnibase_infra`:
+
+```bash
+cd repos/omnibase_infra && infra-up
 ```
 
 ## Project Structure

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -43,7 +43,15 @@ POSTGRES_PASSWORD=your-secure-password
 make setup
 ```
 
-This starts the Docker infrastructure stack:
+This creates `.env` from `.env.example` if it does not already exist. It does **not** start Docker services.
+
+To start the Docker infrastructure stack (PostgreSQL, Redpanda, Valkey), run from `repos/omnibase_infra`:
+
+```bash
+cd repos/omnibase_infra && infra-up
+```
+
+This brings up:
 - **PostgreSQL** (port 5436) -- primary database
 - **Redpanda** (port 19092) -- Kafka-compatible event bus
 - **Valkey** (port 16379) -- Redis-compatible cache
@@ -54,7 +62,7 @@ This starts the Docker infrastructure stack:
 make dev
 ```
 
-This starts the omnidash Next.js development server on port 3000 and shows available `onex` CLI commands.
+This starts the omnidash (Vite + React) development server on port 3000 and shows available `onex` CLI commands.
 
 ## Verifying the Installation
 
@@ -79,7 +87,7 @@ Runs `git pull --ff-only` across all repos.
 ### Stopping Infrastructure
 
 ```bash
-make docker-down
+cd repos/omnibase_infra && infra-down
 ```
 
 ### Running Tests
@@ -107,7 +115,7 @@ The ONEX platform is a distributed node-based system:
 - **omnibase_infra** manages infrastructure (Postgres, Kafka, Valkey) and runtime services
 - **omnibase_spi** defines the service provider interface that nodes implement
 - **omniclaude** integrates Claude Code as an autonomous agent with hooks and skills
-- **omnidash** is the real-time analytics dashboard (Next.js)
+- **omnidash** is the composable widget dashboard (Vite + React)
 - **omniintelligence** provides AI-powered analysis nodes (intent detection, drift, review)
 - **omnimemory** handles document ingestion and semantic search
 - **onex_change_control** enforces governance and drift detection
@@ -116,7 +124,7 @@ The ONEX platform is a distributed node-based system:
 
 ### Docker containers won't start
 
-Check that Docker Desktop is running and ports 5436, 19092, and 16379 are available:
+Docker infrastructure is managed from `repos/omnibase_infra`. Check that Docker Desktop is running and that ports 5436, 19092, and 16379 are available:
 
 ```bash
 lsof -i :5436


### PR DESCRIPTION
## Summary

Refresh omnibase documentation as part of the parent repository documentation refresh wave.

The PR updates stale repository documentation only. Source behavior is unchanged.

## dod_evidence

- Documentation changes were verified against the repository state before editing.
- The doc diff is the proof for this docs-only refresh.
- Central parent evidence is carried in onex_change_control PR #2657.

Evidence-Source: OCC#2659
Evidence-Ticket: OMN-13172

