### PR TITLE
docs(OMN-13570): sanitize omnibase documentation (local-env + OMN-XXXX + renames)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Redpanda (Kafka-compatible) handles all inter-node communication. Nodes subscrib
 
 - Never use `--no-verify` when committing — pre-commit hooks enforce code quality
 - Branch naming: `<author>/<ticket-id>-description`
-- Commit messages: `<type>: <description> [<ticket-id>]` (e.g., `feat: add drift detector [OMN-1234]`)
+- Commit messages: `<type>: <description> [<ticket-id>]` (e.g., `feat: add drift detector [TICKET-42]`)
 
 ## Key Commands
 


### PR DESCRIPTION
## Summary

- OMN-13570: Local-environment trace sanitization — no LAN IPs, `/Users/` paths, host shorthands, personal emails, or SSH identifiers found in any documentation file. All doc files (README.md, CLAUDE.md, docs/GETTING_STARTED.md) are clean.
- OMN-13571: Linear ticket ref removal — one OMN-XXXX reference found in CLAUDE.md (line 92), used as a placeholder example in commit message format documentation. Replaced `[OMN-1234]` with `[TICKET-42]` to preserve the illustrative meaning without embedding a Linear ticket ref in public docs.
- No files required renaming (no filenames contained OMN-XXXX patterns).

## Grep-clean proof

```
# LAN IPs / local-env — returns nothing
git grep -nIE '192\.168\.|[^0-9]\.20[01]\b|/Users/[a-z]|jonah@' -- '*.md' '*.mdx' '*.rst' '*.txt' '*.adoc'

# OMN-XXXX refs — returns nothing
git grep -nIE 'OMN-[0-9]+' -- '*.md' '*.mdx' '*.rst' '*.txt' '*.adoc'
```

Both commands return empty output (verified in worktree).

## Files changed

- `CLAUDE.md` — 1 line changed (example ticket ref in commit format replaced with generic placeholder)

## Renames

None required.

Evidence-Ticket: OMN-13570
Evidence-Source: 87fb618f0273a5694123aed70aa25e4f8a3d1953