### PR TITLE
docs(OMN-16126): scrub live topology and personal paths from public docs — omnibase + OmniNode-ai/.github

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ Repositories are defined in `repos.yaml` and cloned into `repos/` by the install
 | `repos/omnidash/` | Composable widget dashboard (Vite + React) |
 | `repos/omniintelligence/` | Intelligence nodes: intent classification, drift detection, review |
 | `repos/omnimemory/` | Document ingestion and semantic retrieval (RAG) |
-| `repos/omninode_infra/` | API service, k8s manifests, Terraform |
-| `repos/omniweb/` | Landing page |
+| `repos/omninode_infra/` | API service, k8s manifests, Terraform (private repo — org members only) |
+| `repos/omniweb/` | Landing page (private repo — org members only) |
 | `repos/onex_change_control/` | Drift detection and governance |
 
 Each sub-repo has its own `CLAUDE.md` with repo-specific architecture, patterns, and commands.

--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,11 @@ while IFS= read -r line; do
             warn "$current_name already cloned, skipping."
         else
             info "Cloning $current_repo -> $current_name"
-            git clone "https://github.com/$current_repo.git" "$target"
+            # Some repos (e.g. private org repos) may not be accessible to
+            # every caller. Don't let one inaccessible repo abort the whole
+            # install under `set -e` — warn and continue.
+            git clone "https://github.com/$current_repo.git" "$target" ||
+                warn "Failed to clone $current_repo (private repo or no access?), skipping."
         fi
     fi
 done < "$SCRIPT_DIR/repos.yaml"

--- a/repos.yaml
+++ b/repos.yaml
@@ -39,15 +39,19 @@ repositories:
     type: python
     description: Document ingestion and semantic retrieval
 
+  # Private repo — org members only. install.sh clones it with a
+  # best-effort fallback so unauthenticated installs are unaffected.
   - name: omninode_infra
     repo: OmniNode-ai/omninode_infra
     type: terraform
-    description: API service, k8s manifests, Terraform
+    description: API service, k8s manifests, Terraform (private repo — org members only)
 
+  # Private repo — org members only. install.sh clones it with a
+  # best-effort fallback so unauthenticated installs are unaffected.
   - name: omniweb
     repo: OmniNode-ai/omniweb
     type: php
-    description: Landing page
+    description: Landing page (private repo — org members only)
 
   - name: onex_change_control
     repo: OmniNode-ai/onex_change_control


### PR DESCRIPTION
## OMN-16126 — H7: private-repo disclosure + broken public links (omnibase)

Public-docs hygiene fix (Wave 0, item H7). `omnibase` is the public distribution
repo; `repos.yaml` and `CLAUDE.md` named two **private** repos
(`omninode_infra`, `omniweb`) with plain one-line descriptions and no
indication they're inaccessible to non-org visitors, and `install.sh` cloned
every entry in `repos.yaml` unconditionally under `set -euo pipefail` with no
fallback — an unauthenticated/no-access clone of either private repo aborts
the whole install with exit 128 before any public repo gets cloned.

Per plan note N9, making these repos public is a business decision out of
scope here. This PR only:

1. **`repos.yaml`** — annotates the `omninode_infra` and `omniweb` entries as
   `(private repo — org members only)` in their `description` field, plus a
   comment above each row. Entries are kept (not deleted) because they're
   still consumed by `install.sh` for authorized org-member installs.
2. **`CLAUDE.md`** — same annotation on the corresponding rows in the repo
   directory table.
3. **`install.sh`** — the `git clone` call in the repo-cloning loop now falls
   through to `warn` on failure instead of letting `set -e` abort the script,
   matching the existing non-fatal pattern already used for `uv sync` /
   `npm install` a few lines below it. Verified locally: a clone of a
   nonexistent/inaccessible repo under the same `set -euo pipefail` loop
   logic now reaches end-of-script instead of exiting 128.
4. `README.md` and `docs/GETTING_STARTED.md` were checked and do **not**
   reference `omninode_infra`/`omniweb` at all — no change needed there
   (the ticket description named them as affected files; live grep found
   they were already clean).

Docs/comments + one tolerant-fallback shell line only. No behavior change to
any successful-clone path.

### Residual sanctioned occurrences
`repos.yaml` still lists `omninode_infra` / `omniweb` by name (`name:`/`repo:`
fields — required for the installer to locate them for org-member installs);
`CLAUDE.md` still lists both directory paths — both now carry the
`(private repo — org members only)` annotation. No unannotated or
broken-link occurrence remains.

Refs OMN-16126.
