### PR TITLE
fix(OMN-16126): remove private repos from public installer manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,6 @@ Repositories are defined in `repos.yaml` and cloned into `repos/` by the install
 | `repos/omnidash/` | Composable widget dashboard (Vite + React) |
 | `repos/omniintelligence/` | Intelligence nodes: intent classification, drift detection, review |
 | `repos/omnimemory/` | Document ingestion and semantic retrieval (RAG) |
-| `repos/omninode_infra/` | API service, k8s manifests, Terraform (private repo — org members only) |
-| `repos/omniweb/` | Landing page (private repo — org members only) |
 | `repos/onex_change_control/` | Drift detection and governance |
 
 Each sub-repo has its own `CLAUDE.md` with repo-specific architecture, patterns, and commands.

--- a/repos.yaml
+++ b/repos.yaml
@@ -39,20 +39,6 @@ repositories:
     type: python
     description: Document ingestion and semantic retrieval
 
-  # Private repo — org members only. install.sh clones it with a
-  # best-effort fallback so unauthenticated installs are unaffected.
-  - name: omninode_infra
-    repo: OmniNode-ai/omninode_infra
-    type: terraform
-    description: API service, k8s manifests, Terraform (private repo — org members only)
-
-  # Private repo — org members only. install.sh clones it with a
-  # best-effort fallback so unauthenticated installs are unaffected.
-  - name: omniweb
-    repo: OmniNode-ai/omniweb
-    type: php
-    description: Landing page (private repo — org members only)
-
   - name: onex_change_control
     repo: OmniNode-ai/onex_change_control
     type: python


### PR DESCRIPTION
## Summary

Reworks the earlier public-installer private-repo fix (PR #5) to match the operator's resolved direction: the public installer must not reference private repos by name at all, rather than merely annotating them and tolerating the clone failure.

- `#5` kept `omninode_infra` and `omniweb` as named entries in `repos.yaml` and `CLAUDE.md`'s repo table, appending "(private repo — org members only)" to each description, and made `install.sh`'s `git clone` step fall through to `warn` instead of aborting under `set -e`.
- The recorded ruling: a public installer has no legitimate reason to reference private repos by name at all — a tolerant clone still discloses the repos' existence, naming, and a 128 exit that every public caller has to interpret, even once the script no longer hard-aborts.

## Changes

- `repos.yaml`: removed the `omninode_infra` and `omniweb` entries entirely (not annotated — deleted).
- `CLAUDE.md`: removed the corresponding two rows from the repo directory table.
- `README.md` / `docs/GETTING_STARTED.md`: verified via grep — neither ever referenced either repo, so no change needed.
- `install.sh`: unchanged. Its `git clone ... || warn ...` tolerant-fallback pattern (added in #5) stays as defense-in-depth for any future manifest entry, but with both private repos removed from `repos.yaml` the clone loop never attempts them in the first place — there's nothing to warn about on a fresh public run.

## Verification

- `python3 -c "import yaml; ..."` — `repos.yaml` parses to exactly 9 public repos, none private.
- `grep -rn "omninode_infra|omniweb" repos.yaml CLAUDE.md README.md docs/GETTING_STARTED.md install.sh` — zero hits.

## Test plan

- [x] `repos.yaml` contains no `omninode_infra`/`omniweb` entries
- [x] `CLAUDE.md` no longer lists either repo
- [x] `README.md` already excluded both (no edit required)
- [x] `install.sh`'s clone loop iterates only the 9 remaining public repos on a fresh run — no attempt to clone either private repo, no `set -e` abort path exercised
