### PR TITLE
fix(OMN-16259): wire OMNI_HOME and add omnimarket to the public installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Repositories are defined in `repos.yaml` and cloned into `repos/` by the install
 | `repos/omnidash/` | Composable widget dashboard (Vite + React) |
 | `repos/omniintelligence/` | Intelligence nodes: intent classification, drift detection, review |
 | `repos/omnimemory/` | Document ingestion and semantic retrieval (RAG) |
+| `repos/omnimarket/` | Market skill nodes, resolved via `onex skill` (co-installed into the `omnibase_infra` venv) |
 | `repos/onex_change_control/` | Drift detection and governance |
 
 Each sub-repo has its own `CLAUDE.md` with repo-specific architecture, patterns, and commands.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 .PHONY: install setup dev test update status clean help
 
-REPOS_DIR := $(CURDIR)/repos
+# Derived from this Makefile's own location (MAKEFILE_LIST), not $(CURDIR):
+# $(CURDIR) is the invoking shell's cwd, which only matches the checkout
+# when make is run from inside it. `make -f /path/to/omnibase/Makefile
+# install` from elsewhere would otherwise silently point REPOS_DIR/OMNI_HOME
+# at the caller's cwd instead of the checkout.
+MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+REPOS_DIR := $(MAKEFILE_DIR)repos
 SHELL := /bin/bash
 
 # Canonical workspace root every sibling repo clone hangs off of
 # ($OMNI_HOME/<repo>) — same convention the private omni_home workspace
 # uses. Exported so every recipe below (and anything it invokes, e.g. the
 # onex CLI / contract_sweep / the omnimarket drift guard) inherits it.
-# Derived from $(CURDIR), never hardcoded; $(CURDIR) is always set by make
-# itself, so this never silently falls back to an empty/wrong default.
+# Derived from this Makefile's own location, never hardcoded and never
+# silently defaulted to the wrong directory.
 export OMNI_HOME := $(REPOS_DIR)
 
 help: ## Show this help

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ dev: ## Start omnidash dev server and show onex CLI help
 
 test: ## Run tests across all Python repos
 	@echo "==> Running tests..."
-	@for repo in omnibase_core omnibase_infra omnibase_spi omnibase_compat omniclaude omniintelligence omnimemory onex_change_control; do \
+	@for repo in omnibase_core omnibase_infra omnibase_spi omnibase_compat omniclaude omniintelligence omnimemory omnimarket onex_change_control; do \
 		if [ -d $(REPOS_DIR)/$$repo ]; then \
 			echo ""; \
 			echo "--- Testing $$repo ---"; \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,14 @@
 REPOS_DIR := $(CURDIR)/repos
 SHELL := /bin/bash
 
+# Canonical workspace root every sibling repo clone hangs off of
+# ($OMNI_HOME/<repo>) — same convention the private omni_home workspace
+# uses. Exported so every recipe below (and anything it invokes, e.g. the
+# onex CLI / contract_sweep / the omnimarket drift guard) inherits it.
+# Derived from $(CURDIR), never hardcoded; $(CURDIR) is always set by make
+# itself, so this never silently falls back to an empty/wrong default.
+export OMNI_HOME := $(REPOS_DIR)
+
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,13 @@ export OMNI_HOME="$(pwd)/repos"
 Without `OMNI_HOME` set: the omnimarket drift guard fails **open** (silently
 skips its check instead of catching a stale/absent Market skill install),
 and OMNI_HOME-dependent nodes such as `contract_sweep` hard-refuse with
-`OMNI_HOME is not set`. There is no silent fallback — tooling that reads
-`OMNI_HOME` and can't find it fails fast with a clear error.
+`OMNI_HOME is not set`. `install.sh`'s own derivation of `OMNI_HOME` has no
+silent fallback of its own, though — if it can't determine its own checkout
+location (e.g. piped via stdin instead of run from a real checkout) it fails
+fast with a clear error rather than guessing a path. That fail-fast covers
+only `install.sh` deriving the variable, not what happens downstream once
+`OMNI_HOME` is set to the wrong thing or left unset by hand — see the
+drift-guard fail-open behavior above.
 
 After installation, copy the example environment file and fill in your values:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This clones all ONEX repositories, builds Python environments, installs dependen
 | omnidash | Composable widget dashboard (Vite + React) |
 | omniintelligence | Intelligence nodes: intent, drift, review |
 | omnimemory | Document ingestion + semantic retrieval |
+| omnimarket | Market skill nodes (resolved via `onex skill`) |
 | onex_change_control | Drift detection + governance |
 | omnibase_compat | Shared structural package |
 
@@ -78,6 +79,24 @@ omnibase/
 ```
 
 ## Environment Configuration
+
+### OMNI_HOME (required)
+
+`make install` / `install.sh` derive `OMNI_HOME` from the checkout location
+(`<this repo>/repos`, where every sibling repo is cloned) and export it for
+the install run and for every `make` target after it. It's also appended to
+`.env`, but `.env` isn't auto-sourced by your shell — **export it yourself**
+for any `onex`/`uv run` command you run directly (outside `make`):
+
+```bash
+export OMNI_HOME="$(pwd)/repos"
+```
+
+Without `OMNI_HOME` set: the omnimarket drift guard fails **open** (silently
+skips its check instead of catching a stale/absent Market skill install),
+and OMNI_HOME-dependent nodes such as `contract_sweep` hard-refuse with
+`OMNI_HOME is not set`. There is no silent fallback — tooling that reads
+`OMNI_HOME` and can't find it fails fast with a clear error.
 
 After installation, copy the example environment file and fill in your values:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -23,10 +23,39 @@ make install
 ```
 
 This will:
+- Resolve and export `OMNI_HOME` for the install run (see "OMNI_HOME" below)
 - Clone all ONEX repositories into `repos/`
 - Run `uv sync` for each Python repo (creates virtual environments, installs dependencies)
 - Run `npm install` for the omnidash dashboard
+- Install the Market skill package (`omnimarket`) into the `omnibase_infra` venv so
+  `onex skill` can resolve Market nodes (see "Market Skill Nodes" below)
 - Create a `.env` file from the template
+
+## OMNI_HOME
+
+`OMNI_HOME` is the canonical workspace root every cloned repo hangs off of
+(`$OMNI_HOME/<repo>`) — the same convention the private OmniNode workspace uses.
+`install.sh` and the `Makefile` derive it automatically as `<this checkout>/repos`
+(never hardcoded) and export it for the install run and for every `make` target.
+It is also appended to the generated `.env`, but `.env` is not auto-sourced by your
+shell, so **export it yourself** before running `onex`/`uv run` commands directly,
+outside `make`:
+
+```bash
+export OMNI_HOME="$(pwd)/repos"
+```
+
+**What breaks without it:**
+- The omnimarket drift guard (`onex skill` / `onex run` pre-flight check) **fails
+  open** — it silently skips detecting a stale or missing Market skill install
+  instead of catching it, because it can't locate `$OMNI_HOME/omnimarket` to compare
+  against.
+- OMNI_HOME-dependent nodes hard-refuse instead of running. For example
+  `contract_sweep` exits with `'OMNI_HOME is not set — cannot resolve the scan root'`.
+
+If `OMNI_HOME` cannot be derived (e.g. `install.sh` is piped via stdin instead of run
+from a real checkout), `install.sh` fails fast with a clear error rather than falling
+back to a default path.
 
 ## Step 2: Configure Environment
 
@@ -111,6 +140,28 @@ cd repos/omnibase_core
 uv run onex --help
 ```
 
+### Market Skill Nodes
+
+`onex skill <name>` dispatches to nodes provided by `omnimarket`, which is not a
+build dependency of `omnibase_infra` (see the layering note in
+`repos/omnibase_infra/scripts/install-node-skill-package.sh`) — it is co-installed
+into the `omnibase_infra` venv at install time. `make install` / `install.sh`
+perform this automatically. If it was skipped (e.g. `omnimarket` or the
+`omnibase_infra` venv weren't present yet) or you need to re-run it after updating,
+from the `omnibase_infra` repo:
+
+```bash
+cd repos/omnibase_infra
+bash scripts/install-node-skill-package.sh --execute .venv/bin/python
+```
+
+Verify Market nodes resolve (should list resolved node names, not "Unknown node"):
+
+```bash
+cd repos/omnibase_infra
+uv run onex skill <market-node-name>
+```
+
 ## Architecture Overview
 
 The ONEX platform is a distributed node-based system:
@@ -122,6 +173,7 @@ The ONEX platform is a distributed node-based system:
 - **omnidash** is the composable widget dashboard (Vite + React)
 - **omniintelligence** provides AI-powered analysis nodes (intent detection, drift, review)
 - **omnimemory** handles document ingestion and semantic search
+- **omnimarket** provides Market skill nodes, resolved via `onex skill` from a co-install into the `omnibase_infra` venv
 - **onex_change_control** enforces governance and drift detection
 
 ## Troubleshooting

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,26 @@ warn()  { echo -e "${YELLOW}==>${NC} $*"; }
 error() { echo -e "${RED}ERROR:${NC} $*" >&2; }
 
 # ------------------------------------------------------------------
+# 0. Resolve and export OMNI_HOME
+# ------------------------------------------------------------------
+# OMNI_HOME is the canonical workspace root that every sibling repo clone
+# hangs off of ($OMNI_HOME/<repo>) — the same convention the private
+# omni_home workspace uses, so tools written against it (the omnimarket
+# drift guard, OMNI_HOME-dependent node refusals like contract_sweep) work
+# unmodified once the public repos are cloned into $REPOS_DIR.
+#
+# Derived, never hardcoded: OMNI_HOME=$REPOS_DIR, computed from this
+# script's own resolved location (SCRIPT_DIR above). Fails fast — no silent
+# default — if that resolution ever comes back empty.
+if [ -z "$SCRIPT_DIR" ] || [ -z "$REPOS_DIR" ]; then
+    error "Could not resolve the omnibase checkout directory — cannot derive OMNI_HOME."
+    error "This installer must be run as './install.sh' or 'bash install.sh' from a real checkout, not piped via stdin."
+    exit 1
+fi
+export OMNI_HOME="$REPOS_DIR"
+info "OMNI_HOME resolved to $OMNI_HOME"
+
+# ------------------------------------------------------------------
 # 1. Check prerequisites
 # ------------------------------------------------------------------
 info "Checking prerequisites..."
@@ -125,13 +145,40 @@ if [ -d "$REPOS_DIR/omnidash" ] && [ -f "$REPOS_DIR/omnidash/package.json" ]; th
 fi
 
 # ------------------------------------------------------------------
-# 5. Set up environment file
+# 5. Install the Market skill package (Market nodes for `onex skill`)
+# ------------------------------------------------------------------
+# `onex skill` resolves nodes from omnimarket via a co-install into the
+# omnibase_infra venv (the canonical mechanism omnibase_infra itself ships
+# at scripts/install-node-skill-package.sh — never re-implemented here).
+# Both repos and the infra venv must exist for this to be possible; skip
+# (non-fatal, matching the rest of this script's degrade-gracefully
+# posture) if either prerequisite didn't clone/build successfully above.
+skill_installer="$REPOS_DIR/omnibase_infra/scripts/install-node-skill-package.sh"
+infra_python="$REPOS_DIR/omnibase_infra/.venv/bin/python"
+if [ -d "$REPOS_DIR/omnimarket" ] && [ -x "$skill_installer" ] && [ -x "$infra_python" ]; then
+    info "Installing Market skill package (omnimarket) into the omnibase_infra venv..."
+    bash "$skill_installer" --execute "$infra_python" ||
+        warn "Failed to install the Market skill package (non-fatal) — re-run manually: bash $skill_installer --execute $infra_python"
+else
+    warn "Skipping Market skill package install: omnimarket and/or the omnibase_infra venv are not present."
+    warn "Market skill nodes will show as \"Unknown node\" under 'onex skill' until you run:"
+    warn "  bash $skill_installer --execute $infra_python"
+fi
+
+# ------------------------------------------------------------------
+# 6. Set up environment file
 # ------------------------------------------------------------------
 if [ ! -f "$SCRIPT_DIR/.env" ]; then
     cp "$SCRIPT_DIR/.env.example" "$SCRIPT_DIR/.env"
     info "Created .env from template. Edit it with your configuration."
 else
     info ".env already exists, skipping."
+fi
+
+if ! grep -q '^OMNI_HOME=' "$SCRIPT_DIR/.env" 2>/dev/null; then
+    { echo ""; echo "# Canonical workspace root (installer-derived) — required by the"; \
+      echo "# omnimarket drift guard and OMNI_HOME-dependent node refusals."; \
+      echo "OMNI_HOME=$OMNI_HOME"; } >> "$SCRIPT_DIR/.env"
 fi
 
 # ------------------------------------------------------------------
@@ -141,10 +188,12 @@ echo ""
 info "Installation complete!"
 echo ""
 echo "Next steps:"
-echo "  1. Edit .env with your configuration (passwords, endpoints)"
-echo "  2. Run 'make setup' to create your .env file (does NOT start Docker)"
-echo "  3. Run 'make dev' to start development servers"
-echo "  4. Run 'make status' to check everything is running"
+echo "  1. Export OMNI_HOME in your shell (required — see docs/GETTING_STARTED.md):"
+echo "       export OMNI_HOME=\"$OMNI_HOME\""
+echo "  2. Edit .env with your configuration (passwords, endpoints)"
+echo "  3. Run 'make setup' to create your .env file (does NOT start Docker)"
+echo "  4. Run 'make dev' to start development servers"
+echo "  5. Run 'make status' to check everything is running"
 echo ""
 echo "Optional: to run the full self-hosted stack (Docker), see docs/GETTING_STARTED.md"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPOS_DIR="$SCRIPT_DIR/repos"
-
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -24,13 +21,22 @@ error() { echo -e "${RED}ERROR:${NC} $*" >&2; }
 # unmodified once the public repos are cloned into $REPOS_DIR.
 #
 # Derived, never hardcoded: OMNI_HOME=$REPOS_DIR, computed from this
-# script's own resolved location (SCRIPT_DIR above). Fails fast — no silent
-# default — if that resolution ever comes back empty.
-if [ -z "$SCRIPT_DIR" ] || [ -z "$REPOS_DIR" ]; then
-    error "Could not resolve the omnibase checkout directory — cannot derive OMNI_HOME."
-    error "This installer must be run as './install.sh' or 'bash install.sh' from a real checkout, not piped via stdin."
+# script's own resolved location. Fails fast — no silent default — when
+# that location cannot be determined, which is exactly the "piped via
+# stdin" case (curl ... | bash, or bash < install.sh): bash never
+# populates BASH_SOURCE[0] for a script read from stdin, so this is
+# checked explicitly, before ever calling dirname/cd on it — a plain
+# `${BASH_SOURCE[0]}` reference under `set -u` would abort on "unbound
+# variable" here instead of reaching this message, and `dirname ""`
+# resolves to "." (the caller's $PWD), which would silently derive
+# OMNI_HOME from the wrong directory instead of failing at all.
+if [ -z "${BASH_SOURCE[0]:-}" ]; then
+    error "Could not determine this script's own location — cannot derive OMNI_HOME."
+    error "This installer must be run as './install.sh' or 'bash install.sh' from a real checkout, not piped via stdin (e.g. 'curl ... | bash')."
     exit 1
 fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOS_DIR="$SCRIPT_DIR/repos"
 export OMNI_HOME="$REPOS_DIR"
 info "OMNI_HOME resolved to $OMNI_HOME"
 

--- a/repos.yaml
+++ b/repos.yaml
@@ -39,6 +39,11 @@ repositories:
     type: python
     description: Document ingestion and semantic retrieval
 
+  - name: omnimarket
+    repo: OmniNode-ai/omnimarket
+    type: python
+    description: Market skill nodes (onex skill), co-installed into the omnibase_infra venv
+
   - name: onex_change_control
     repo: OmniNode-ai/onex_change_control
     type: python

--- a/tests/test_install_omni_home_and_omnimarket.sh
+++ b/tests/test_install_omni_home_and_omnimarket.sh
@@ -129,14 +129,33 @@ else
 fi
 
 # And the normal (non-piped) invocation must NOT trip the guard — it must
-# resolve and export a real, non-empty OMNI_HOME under this checkout.
-normal_out="$(cd "$REPO_ROOT" && timeout 5 bash install.sh </dev/null 2>&1 || true)"
-if echo "$normal_out" | grep -q "OMNI_HOME resolved to $REPO_ROOT/repos"; then
-    ok "running install.sh normally (./install.sh) resolves OMNI_HOME to the real checkout's repos/ dir, not silently to something else"
+# resolve and export a real, non-empty OMNI_HOME. Exercised against a mktemp
+# copy of install.sh + repos.yaml (the pattern the heavy (b)/(c) block below
+# already uses), NEVER against $REPO_ROOT itself: install.sh's own next step
+# is `mkdir -p "$REPOS_DIR"` followed by real `git clone`s under
+# $SCRIPT_DIR/repos, so running it in-place would create/clone into
+# $REPO_ROOT/repos, and the timeout-then-rm-rf that used to follow would
+# silently delete a real repos/ tree (and any uncommitted work in it) on any
+# machine that had already run `make install` — reproduced live: seeding
+# repos/omnibase_core/MY_UNCOMMITTED_WORK.txt then running this test with
+# --skip-heavy still exited 0 and deleted repos/ entirely. A mktemp copy
+# removes that blast radius while still exercising the real install.sh bytes
+# and the real fail-fast guard under a real, non-piped invocation.
+# Re-resolved through `cd ... && pwd` (not the raw mktemp -d output) because
+# `${TMPDIR:-/tmp}` on macOS already ends in a slash, which mktemp echoes
+# straight through as a literal "//" in the path — install.sh's own
+# `SCRIPT_DIR="$(cd ... && pwd)"` normalizes that away, so comparing the raw
+# mktemp path against install.sh's printed OMNI_HOME would false-FAIL on a
+# string mismatch even though both refer to the same directory.
+NORMAL_WORK="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/omn16259-normalrun.XXXXXX")" && pwd)"
+cp "$REPO_ROOT/install.sh" "$REPO_ROOT/repos.yaml" "$NORMAL_WORK/"
+normal_out="$(cd "$NORMAL_WORK" && timeout 5 bash install.sh </dev/null 2>&1 || true)"
+if echo "$normal_out" | grep -q "OMNI_HOME resolved to $NORMAL_WORK/repos"; then
+    ok "running install.sh normally (./install.sh) resolves OMNI_HOME to its own checkout's repos/ dir, not silently to something else"
 else
     bad "running install.sh normally did not resolve OMNI_HOME as expected: $normal_out"
 fi
-rm -rf "$REPO_ROOT/repos" 2>/dev/null || true
+rm -rf "$NORMAL_WORK" 2>/dev/null || true
 
 # ----------------------------------------------------------------------------
 # (d) No hardcoded absolute paths introduced

--- a/tests/test_install_omni_home_and_omnimarket.sh
+++ b/tests/test_install_omni_home_and_omnimarket.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+#
+# test_install_omni_home_and_omnimarket.sh (OMN-16259)
+# ----------------------------------------------------------------------------
+# Drives the REAL install.sh / Makefile / repos.yaml artifacts in this repo
+# (never a mock/surrogate) and proves the two OMN-16259 defects are fixed:
+#
+#   (a) OMNI_HOME is wired + documented, and its resolution fails fast with
+#       no silent default.
+#   (b) omnimarket is in repos.yaml and `make install` clones it.
+#   (c) the Market skill co-install runs (or is documented) so `onex skill`
+#       can resolve Market nodes instead of "Unknown node"/"Unknown skill".
+#   (d) no hardcoded /Users/ or /Volumes/ paths were introduced.
+#
+# Test (b)/(c) run a REAL `make install` from a clean clone of this checkout
+# (network + uv sync + npm install + the omnimarket co-install) — this is
+# slow (multiple minutes) by nature of what it proves. Run directly, not
+# under a test framework: there is no pytest/CI harness in this repo (a
+# public shell+docs installer), matching its existing convention.
+#
+# Usage: bash tests/test_install_omni_home_and_omnimarket.sh [--skip-heavy]
+#   --skip-heavy  run only the fast, static (a)/(d) checks — skips the real
+#                 `make install` clean-clone run for (b)/(c). Useful for a
+#                 quick pre-push smoke; the full run is still required once
+#                 per change to install.sh/Makefile/repos.yaml.
+# ----------------------------------------------------------------------------
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKIP_HEAVY=0
+[ "${1:-}" = "--skip-heavy" ] && SKIP_HEAVY=1
+
+PASS=0
+FAIL=0
+
+ok()   { echo "  PASS: $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $*"; FAIL=$((FAIL + 1)); }
+hdr()  { echo ""; echo "=== $* ==="; }
+
+# ----------------------------------------------------------------------------
+# (a) OMNI_HOME wired + documented
+# ----------------------------------------------------------------------------
+hdr "(a) OMNI_HOME wiring + docs"
+
+if grep -q 'OMNI_HOME' "$REPO_ROOT/install.sh"; then
+    ok "install.sh references OMNI_HOME"
+else
+    bad "install.sh does not reference OMNI_HOME"
+fi
+
+if grep -q 'export OMNI_HOME' "$REPO_ROOT/Makefile"; then
+    ok "Makefile exports OMNI_HOME"
+else
+    bad "Makefile does not export OMNI_HOME"
+fi
+
+for doc in README.md docs/GETTING_STARTED.md; do
+    if grep -q 'OMNI_HOME' "$REPO_ROOT/$doc"; then
+        ok "$doc documents OMNI_HOME"
+    else
+        bad "$doc does not document OMNI_HOME"
+    fi
+done
+
+if grep -qi 'drift.*guard\|fail.*open' "$REPO_ROOT/README.md" "$REPO_ROOT/docs/GETTING_STARTED.md"; then
+    ok "docs state the drift-guard fail-open consequence"
+else
+    bad "docs do not state the drift-guard fail-open consequence"
+fi
+
+if grep -q 'OMNI_HOME is not set\|contract_sweep' "$REPO_ROOT/README.md" "$REPO_ROOT/docs/GETTING_STARTED.md" 2>/dev/null; then
+    ok "docs state the OMNI_HOME-dependent node refusal (contract_sweep) consequence"
+else
+    bad "docs do not state the OMNI_HOME-dependent node refusal consequence"
+fi
+
+# Fail-fast, no silent default: OMNI_HOME must never be defined with a `:-`
+# bash-parameter-expansion default anywhere in the changed artifacts, and
+# install.sh's own derivation must have an explicit non-empty guard before
+# it exports OMNI_HOME.
+if grep -qE '\$\{OMNI_HOME(:-|-|:=)' "$REPO_ROOT/install.sh" "$REPO_ROOT/Makefile"; then
+    bad "found a silent-default OMNI_HOME expansion (\${OMNI_HOME:-...}) in install.sh/Makefile"
+else
+    ok "no silent-default OMNI_HOME expansion in install.sh/Makefile"
+fi
+
+if grep -B8 '^export OMNI_HOME=' "$REPO_ROOT/install.sh" | grep -q '\-z "\$SCRIPT_DIR"\|\-z "\$REPOS_DIR"'; then
+    ok "install.sh guards OMNI_HOME derivation with an explicit non-empty check before export"
+else
+    bad "install.sh does not guard OMNI_HOME derivation before export"
+fi
+
+# Real fail-fast exercise: if REPOS_DIR/SCRIPT_DIR ever resolve empty, the
+# guard must exit non-zero with a message on stderr, not proceed silently.
+# Exercise the actual guard block (extracted from install.sh, not
+# reimplemented) with SCRIPT_DIR/REPOS_DIR forced empty.
+guard_block="$(sed -n '/^if \[ -z "\$SCRIPT_DIR" \]/,/^fi$/p' "$REPO_ROOT/install.sh")"
+if [ -z "$guard_block" ]; then
+    bad "could not locate the OMNI_HOME fail-fast guard block in install.sh to exercise it"
+else
+    guard_out="$(SCRIPT_DIR="" REPOS_DIR="" bash -c "
+        RED='' GREEN='' YELLOW='' NC=''
+        error() { echo \"ERROR: \$*\" >&2; }
+        $guard_block
+        echo SHOULD_NOT_REACH_HERE
+    " 2>&1)"
+    guard_status=$?
+    if [ "$guard_status" -ne 0 ] && ! echo "$guard_out" | grep -q "SHOULD_NOT_REACH_HERE"; then
+        ok "OMNI_HOME fail-fast guard exits non-zero and never reaches past itself when derivation is empty"
+    else
+        bad "OMNI_HOME fail-fast guard did not fail closed (status=$guard_status, out=$guard_out)"
+    fi
+fi
+
+# ----------------------------------------------------------------------------
+# (d) No hardcoded absolute paths introduced
+# ----------------------------------------------------------------------------
+hdr "(d) No hardcoded /Users/ or /Volumes/ paths"
+
+changed_files="install.sh Makefile repos.yaml README.md docs/GETTING_STARTED.md"
+hardcoded_hits=""
+for f in $changed_files; do
+    hits="$(grep -nE '/Users/|/Volumes/' "$REPO_ROOT/$f" 2>/dev/null || true)"
+    if [ -n "$hits" ]; then
+        hardcoded_hits="$hardcoded_hits\n$f:\n$hits"
+    fi
+done
+if [ -n "$hardcoded_hits" ]; then
+    bad "hardcoded absolute path(s) found:$hardcoded_hits"
+else
+    ok "zero /Users/ or /Volumes/ hits in changed files"
+fi
+
+# ----------------------------------------------------------------------------
+# (b) repos.yaml gains omnimarket with correct metadata
+# ----------------------------------------------------------------------------
+hdr "(b) repos.yaml omnimarket entry"
+
+if grep -A2 'name: omnimarket' "$REPO_ROOT/repos.yaml" | grep -q 'repo: OmniNode-ai/omnimarket'; then
+    ok "repos.yaml has an omnimarket entry with repo: OmniNode-ai/omnimarket"
+else
+    bad "repos.yaml is missing a correctly-shaped omnimarket entry"
+fi
+
+if [ "$SKIP_HEAVY" -eq 1 ]; then
+    echo ""
+    echo "--skip-heavy passed: skipping the real make install clean-clone run for (b)/(c)."
+    echo ""
+    echo "Results: $PASS passed, $FAIL failed (heavy checks skipped)"
+    [ "$FAIL" -eq 0 ]
+    exit $?
+fi
+
+# ----------------------------------------------------------------------------
+# (b)+(c) REAL make install from a clean clone; omnimarket clones; Market
+# skill co-install runs; onex skill resolves a Market node.
+# ----------------------------------------------------------------------------
+hdr "(b)+(c) real 'make install' from a clean clone"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/omn16259-installtest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Plain copy (not `git worktree add`) so uncommitted working-tree edits are
+# included — this is what a real clean-clone user would get once the diff
+# lands, minus needing a commit first. Excludes repos/ (never populated yet
+# here) and .git (irrelevant to install.sh, which is pure filesystem).
+echo "copying this checkout (with local changes) into $WORK/omnibase ..."
+mkdir -p "$WORK/omnibase"
+if ! (cd "$REPO_ROOT" && tar cf - --exclude=repos --exclude=.git . | (cd "$WORK/omnibase" && tar xf -)); then
+    bad "could not copy the current checkout into a clean-clone test dir"
+else
+    (
+        cd "$WORK/omnibase" || exit 1
+        echo "running make install (this clones ~10 repos, uv-syncs each, npm-installs omnidash, and co-installs omnimarket into the infra venv — this takes several minutes)..."
+        make install
+    ) >"$WORK/install.log" 2>&1
+    install_status=$?
+    echo "  (full log: $WORK/install.log, tail below)"
+    tail -30 "$WORK/install.log"
+
+    if [ "$install_status" -ne 0 ]; then
+        bad "make install exited non-zero ($install_status)"
+    else
+        ok "make install completed"
+    fi
+
+    if [ -d "$WORK/omnibase/repos/omnimarket/.git" ]; then
+        ok "repos/omnimarket was cloned"
+        commit="$(git -C "$WORK/omnibase/repos/omnimarket" rev-parse HEAD 2>/dev/null)"
+        if [ -n "$commit" ]; then
+            ok "repos/omnimarket is at a valid commit ($commit)"
+        else
+            bad "repos/omnimarket has no resolvable HEAD commit"
+        fi
+    else
+        bad "repos/omnimarket was NOT cloned by make install"
+    fi
+
+    infra_python="$WORK/omnibase/repos/omnibase_infra/.venv/bin/python"
+    if [ -x "$infra_python" ]; then
+        ep_check="$("$infra_python" - <<'PYEOF'
+import sys
+from importlib.metadata import entry_points
+eps = {e.name for e in entry_points(group="onex.nodes")}
+required = {"node_pr_lifecycle_orchestrator", "node_session_orchestrator", "node_aislop_sweep"}
+missing = sorted(required - eps)
+if missing:
+    print(f"MISSING:{missing}")
+    sys.exit(1)
+print(f"OK:{len(eps)}")
+PYEOF
+)"
+        ep_status=$?
+        if [ "$ep_status" -eq 0 ]; then
+            ok "Market nodes resolve via onex.nodes entry points in the infra venv ($ep_check)"
+        else
+            bad "Market nodes did not resolve via onex.nodes entry points ($ep_check)"
+        fi
+
+        skill_out="$(cd "$WORK/omnibase/repos/omnibase_infra" && OMNI_HOME="$WORK/omnibase/repos" "$infra_python" -c "
+from omnibase_infra.cli.cli_node import _resolve_packaged_contract
+try:
+    path = _resolve_packaged_contract('node_aislop_sweep')
+    print(f'RESOLVED:{path}')
+except Exception as e:
+    print(f'FAILED:{e}')
+" 2>&1)"
+        if echo "$skill_out" | grep -q '^RESOLVED:'; then
+            ok "onex resolves the Market node 'node_aislop_sweep' to a packaged contract (not Unknown node): $skill_out"
+        else
+            bad "onex could not resolve the Market node 'node_aislop_sweep': $skill_out"
+        fi
+    else
+        bad "no omnibase_infra venv python found at $infra_python — cannot verify Market node resolution"
+    fi
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test_install_omni_home_and_omnimarket.sh
+++ b/tests/test_install_omni_home_and_omnimarket.sh
@@ -39,6 +39,37 @@ ok()   { echo "  PASS: $*"; PASS=$((PASS + 1)); }
 bad()  { echo "  FAIL: $*"; FAIL=$((FAIL + 1)); }
 hdr()  { echo ""; echo "=== $* ==="; }
 
+# Portable timeout: prefer GNU `timeout` (Linux, or macOS with coreutils
+# installed), fall back to `gtimeout` (macOS + `brew install coreutils`),
+# and if neither exists — stock macOS ships neither — background the job
+# ourselves and kill it after the deadline, so this test doesn't hard-fail
+# with "command not found" on a contractor's unmodified Mac.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    TIMEOUT_BIN=""
+fi
+
+run_with_timeout() {
+    local secs="$1"
+    shift
+    if [ -n "$TIMEOUT_BIN" ]; then
+        "$TIMEOUT_BIN" "$secs" "$@"
+        return $?
+    fi
+    "$@" &
+    local pid=$!
+    ( sleep "$secs" && kill -9 "$pid" 2>/dev/null ) &
+    local watchdog=$!
+    local status=0
+    wait "$pid" 2>/dev/null || status=$?
+    kill "$watchdog" 2>/dev/null
+    wait "$watchdog" 2>/dev/null
+    return "$status"
+}
+
 # ----------------------------------------------------------------------------
 # (a) OMNI_HOME wired + documented
 # ----------------------------------------------------------------------------
@@ -149,7 +180,7 @@ fi
 # string mismatch even though both refer to the same directory.
 NORMAL_WORK="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/omn16259-normalrun.XXXXXX")" && pwd)"
 cp "$REPO_ROOT/install.sh" "$REPO_ROOT/repos.yaml" "$NORMAL_WORK/"
-normal_out="$(cd "$NORMAL_WORK" && timeout 5 bash install.sh </dev/null 2>&1 || true)"
+normal_out="$(cd "$NORMAL_WORK" && run_with_timeout 5 bash install.sh </dev/null 2>&1 || true)"
 if echo "$normal_out" | grep -q "OMNI_HOME resolved to $NORMAL_WORK/repos"; then
     ok "running install.sh normally (./install.sh) resolves OMNI_HOME to its own checkout's repos/ dir, not silently to something else"
 else

--- a/tests/test_install_omni_home_and_omnimarket.sh
+++ b/tests/test_install_omni_home_and_omnimarket.sh
@@ -86,33 +86,57 @@ else
     ok "no silent-default OMNI_HOME expansion in install.sh/Makefile"
 fi
 
-if grep -B8 '^export OMNI_HOME=' "$REPO_ROOT/install.sh" | grep -q '\-z "\$SCRIPT_DIR"\|\-z "\$REPOS_DIR"'; then
-    ok "install.sh guards OMNI_HOME derivation with an explicit non-empty check before export"
+if grep -B6 '^SCRIPT_DIR=' "$REPO_ROOT/install.sh" | grep -q '\-z "\${BASH_SOURCE\[0\]:-}"'; then
+    ok "install.sh guards OMNI_HOME derivation with an explicit non-empty check before deriving SCRIPT_DIR"
 else
-    bad "install.sh does not guard OMNI_HOME derivation before export"
+    bad "install.sh does not guard OMNI_HOME derivation before deriving SCRIPT_DIR"
 fi
 
-# Real fail-fast exercise: if REPOS_DIR/SCRIPT_DIR ever resolve empty, the
-# guard must exit non-zero with a message on stderr, not proceed silently.
-# Exercise the actual guard block (extracted from install.sh, not
-# reimplemented) with SCRIPT_DIR/REPOS_DIR forced empty.
-guard_block="$(sed -n '/^if \[ -z "\$SCRIPT_DIR" \]/,/^fi$/p' "$REPO_ROOT/install.sh")"
-if [ -z "$guard_block" ]; then
-    bad "could not locate the OMNI_HOME fail-fast guard block in install.sh to exercise it"
+# ----------------------------------------------------------------------------
+# Real fail-fast exercise: drive install.sh ITSELF end to end (never an
+# extracted/reimplemented snippet, never a forced environment variable the
+# script could not actually produce). bash never populates BASH_SOURCE[0]
+# for a script it reads from stdin rather than a file — that's exactly what
+# happens when install.sh is piped, e.g. `curl ... | bash` or
+# `bash < install.sh` — so piping it is a real, reachable way to trigger the
+# guard, not a synthetic precondition. This exercises real script bytes,
+# real `set -euo pipefail`, the real guard, and the real exit code + stderr
+# text a piped-in user would actually see.
+# ----------------------------------------------------------------------------
+piped_out="$(bash < "$REPO_ROOT/install.sh" 2>&1)"
+piped_status=$?
+if [ "$piped_status" -ne 0 ] \
+    && echo "$piped_out" | grep -q "cannot derive OMNI_HOME" \
+    && ! echo "$piped_out" | grep -q "OMNI_HOME resolved to"; then
+    ok "piping the real install.sh via stdin (bash < install.sh) fails fast (status=$piped_status) before ever exporting OMNI_HOME"
 else
-    guard_out="$(SCRIPT_DIR="" REPOS_DIR="" bash -c "
-        RED='' GREEN='' YELLOW='' NC=''
-        error() { echo \"ERROR: \$*\" >&2; }
-        $guard_block
-        echo SHOULD_NOT_REACH_HERE
-    " 2>&1)"
-    guard_status=$?
-    if [ "$guard_status" -ne 0 ] && ! echo "$guard_out" | grep -q "SHOULD_NOT_REACH_HERE"; then
-        ok "OMNI_HOME fail-fast guard exits non-zero and never reaches past itself when derivation is empty"
-    else
-        bad "OMNI_HOME fail-fast guard did not fail closed (status=$guard_status, out=$guard_out)"
-    fi
+    bad "piping the real install.sh via stdin did not fail fast as expected (status=$piped_status, out=$piped_out)"
 fi
+
+# The curl-pipe idiom the docs call out (curl ... | bash) most commonly
+# reaches bash as `bash -c "$(curl ...)"` or an equivalent command
+# substitution rather than plain stdin redirection; same underlying
+# BASH_SOURCE[0]-unset condition, exercised the same real way against the
+# same real file.
+curlpipe_out="$(bash -c "$(cat "$REPO_ROOT/install.sh")" 2>&1)"
+curlpipe_status=$?
+if [ "$curlpipe_status" -ne 0 ] \
+    && echo "$curlpipe_out" | grep -q "cannot derive OMNI_HOME" \
+    && ! echo "$curlpipe_out" | grep -q "OMNI_HOME resolved to"; then
+    ok "the curl-pipe idiom (bash -c \"\$(cat install.sh)\") fails fast before ever exporting OMNI_HOME"
+else
+    bad "the curl-pipe idiom did not fail fast as expected (status=$curlpipe_status, out=$curlpipe_out)"
+fi
+
+# And the normal (non-piped) invocation must NOT trip the guard — it must
+# resolve and export a real, non-empty OMNI_HOME under this checkout.
+normal_out="$(cd "$REPO_ROOT" && timeout 5 bash install.sh </dev/null 2>&1 || true)"
+if echo "$normal_out" | grep -q "OMNI_HOME resolved to $REPO_ROOT/repos"; then
+    ok "running install.sh normally (./install.sh) resolves OMNI_HOME to the real checkout's repos/ dir, not silently to something else"
+else
+    bad "running install.sh normally did not resolve OMNI_HOME as expected: $normal_out"
+fi
+rm -rf "$REPO_ROOT/repos" 2>/dev/null || true
 
 # ----------------------------------------------------------------------------
 # (d) No hardcoded absolute paths introduced


### PR DESCRIPTION
## OMN-16259

Fixes two defects in the public omnibase installer (found 2026-08-19 while verifying a contractor onboarding path against `OmniNode-ai/omnibase` HEAD `b82c8e3`, re-verified live at the current HEAD):

1. **OMNI_HOME was never exported/wired/documented** anywhere in `install.sh`, `Makefile`, or `docs/GETTING_STARTED.md` — a public quick-start user hit the `omnimarket` drift guard's fail-open path and OMNI_HOME-dependent node refusals (e.g. `contract_sweep`'s `'OMNI_HOME is not set'` hard-fail).
2. **`omnimarket` (a public repo, `gh api repos/OmniNode-ai/omnimarket --jq .private` → `false`) was absent from `repos.yaml`** — `make install` never cloned it, so Market skill nodes and the infra-venv co-install path (`omnibase_infra/scripts/install-node-skill-package.sh`) were unreachable and `onex skill` could not resolve market nodes.

## Remediation round (this push)

An adversarial verifier found the first attempt's OMNI_HOME fail-fast guard was **dead code**: `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` runs under `set -euo pipefail`, so a piped invocation (`bash < install.sh`, the `curl ... | bash` idiom) aborts on bash's own `BASH_SOURCE[0]: unbound variable` error at that line — before the guard's `-z "$SCRIPT_DIR"` check could ever run. The docs claiming "fails fast with a clear error" for that case were therefore false, and the test exercising the guard was a surrogate (sed-extracted block, run with `SCRIPT_DIR=""`/`REPOS_DIR=""` forced — a precondition install.sh can never actually reach).

Fixed by checking `-z "${BASH_SOURCE[0]:-}"` explicitly, *before* ever passing it to `dirname`/`cd`. This is the real, reachable signal — bash never populates `BASH_SOURCE[0]` for a script read from stdin rather than a file. Verified live that the old fallback path was worse than just unreachable: `dirname ""` resolves to `"."` and `cd . && pwd` succeeds, so once BASH_SOURCE naively defaulted to empty the old guard would have silently derived `OMNI_HOME` from the caller's `$PWD` instead of failing at all — a silent-default bug, not just dead code.

Also fixed:
- `README.md:98-99` asserted a blanket "no silent fallback" claim that contradicted the drift-guard fail-open statement two lines above it (`95-96`). Scoped the claim to `install.sh`'s own derivation of `OMNI_HOME`, not every downstream consumer of the variable (the drift guard genuinely does fail open if `OMNI_HOME` is unset/wrong at runtime).
- `tests/test_install_omni_home_and_omnimarket.sh`: replaced the surrogate guard-block exercise with real invocations of `install.sh` itself — piped via stdin (`bash < install.sh`), via the curl-pipe idiom (`bash -c "$(cat install.sh)"`), and normally (`./install.sh`, asserting `OMNI_HOME resolved to <repo>/repos` and nothing else) — asserting the actual exit code and actual stderr text a user would see.
- `docs/GETTING_STARTED.md:56-58` needed no change: once the guard is genuinely reachable, its existing "fails fast rather than falling back to a default path" claim became true rather than aspirational.

## Seam definition

Boundary this change reads/writes, field by field:

- **`repos.yaml` entry schema** (read by `install.sh`'s line-based parser): `name`, `repo`, `type`, `description` keys, in that order per entry (the parser fires on seeing `type:` after previously capturing `name:`/`repo:`). The new `omnimarket` entry: `name: omnimarket`, `repo: OmniNode-ai/omnimarket`, `type: python`, matching every existing entry's shape exactly.
- **`OMNI_HOME` value**: derived as `$REPOS_DIR` (`<this checkout>/repos`) — the directory sibling repo clones live in — matching the `$OMNI_HOME/<repo>` convention already read by `omnibase_core.utils.util_omni_home_paths.resolve_omnibase_infra_path()` (`$OMNI_HOME/omnibase_infra`) and `omnibase_infra.cli.omnimarket_drift_guard` (`$OMNI_HOME/omnimarket`). Exported by both `install.sh` (for its own run) and the `Makefile` (`export OMNI_HOME := $(REPOS_DIR)`, inherited by every recipe). Written once into the generated `.env` as `OMNI_HOME=<path>` for reference; documented as needing a manual `export` for any direct (non-`make`) `onex`/`uv run` invocation, since `.env` isn't auto-sourced.
- **OMNI_HOME derivation fail-fast signal**: `-z "${BASH_SOURCE[0]:-}"`, checked before any `dirname`/`cd` call — the one condition that genuinely distinguishes "run from a real checkout" from "piped via stdin," since bash leaves `BASH_SOURCE[0]` unset (not merely empty) for a script it reads from stdin.
- **Market skill co-install invocation**: `install.sh` calls `omnibase_infra/scripts/install-node-skill-package.sh --execute <omnibase_infra venv python>` — the existing canonical co-install mechanism in `omnibase_infra`, not reimplemented here. Guarded on `omnimarket/` and the infra venv both existing; non-fatal warn + a manual re-run pointer otherwise, matching this script's existing degrade-gracefully posture for every other step.

## Acceptance criteria → test mapping

All four criteria are driven against the real artifacts by `tests/test_install_omni_home_and_omnimarket.sh` (no CI/pytest harness exists in this repo — a shell+docs installer — so this is a standalone bash test script run directly):

| Criterion | Test |
|---|---|
| (a) OMNI_HOME set + documented, fails fast, no silent default | Static greps for OMNI_HOME wiring in `install.sh`/`Makefile`/`README.md`/`docs/GETTING_STARTED.md`, for the drift-guard-fail-open and contract_sweep-refusal consequences in the docs, for the absence of any `${OMNI_HOME:-...}` silent-default pattern, plus **real invocations of `install.sh` itself**: piped via stdin, via the curl-pipe idiom, and run normally — asserting real exit codes and real stderr/stdout text, not an extracted snippet |
| (b) repos.yaml has omnimarket; `make install` clones it | Static grep of the `repos.yaml` entry shape, plus a **real** `make install` run from a clean copy of this checkout (clones ~10 repos, `uv sync`s each, `npm install`s omnidash) confirming `repos/omnimarket/.git` exists and resolves to a valid commit |
| (c) `onex skill` resolves market nodes post-install | Same real `make install` run: confirms 515 `onex.nodes` entry points including `node_pr_lifecycle_orchestrator`/`node_session_orchestrator`/`node_aislop_sweep` resolve in the infra venv, and that `_resolve_packaged_contract('node_aislop_sweep')` (the exact function that raises `"Unknown node"`) resolves to a packaged `contract.yaml` instead |
| (d) no hardcoded `/Users/`/`/Volumes/` paths; fail-fast, no silent default | Grep across every changed file — zero hits — plus the same real-invocation exercise as (a) |

**RED-before/GREEN-after (re-verified this round)**: ran the new test file against the actual pre-fix `install.sh` (the file from before this remediation commit) and reproduced the verifier's exact disproof — `bash: line 4: BASH_SOURCE[0]: unbound variable` / `bash: line 4: cd: null directory` — as 3 genuine failures (10 passed, 3 failed, `--skip-heavy`). Against the fixed `install.sh`: 13/13 green on `--skip-heavy`, and **18/18 green on the full run including the real `make install` clean-clone path** (network clone of ~10 repos + `uv sync` + `npm install` + omnimarket co-install + live `onex.nodes` entry-point resolution).

## Gates

No `.pre-commit-config.yaml`, no `.github/workflows/`, and no pytest harness exist in this repo (a public shell+docs installer) — verified live before starting. Gates run: `bash -n install.sh` (syntax), `shellcheck install.sh` (clean except one pre-existing, unrelated `SC2034` warning on an untouched line), the hardcoded-path grep, and the full `tests/test_install_omni_home_and_omnimarket.sh` run described above (real `make install`, real network clone, real `onex skill` resolution — no mocks). All gates + the push ran on `stickybeatz-studio` (this session's own host).

## Out-of-scope discipline

No changes to `omnimarket` or `omnibase_infra` — only invokes the existing `install-node-skill-package.sh` mechanism that already ships there. No destructive actions, no cloud/AWS mutation, no prod promotion. Scope held to exactly `install.sh`, `Makefile`, `repos.yaml`, `README.md`, `docs/GETTING_STARTED.md`, plus the test script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Omnimarket repository and Market skill package to the workspace.
  * Installers now automatically configure and export the workspace root through `OMNI_HOME`.
  * Market skills can be installed and resolved as part of setup.

* **Documentation**
  * Expanded setup and architecture guidance for Omnimarket, `OMNI_HOME`, installation, and troubleshooting.

* **Bug Fixes**
  * Installation now fails clearly when the workspace location cannot be determined.

* **Tests**
  * Added integration coverage for installation, repository setup, environment configuration, and Market skill resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->