### PR TITLE
fix(OMN-16312): correct stale omnidash description in repos.yaml

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -27,7 +27,7 @@ repositories:
   - name: omnidash
     repo: OmniNode-ai/omnidash
     type: node
-    description: Next.js analytics dashboard
+    description: Composable widget dashboard (Vite + React)
 
   - name: omniintelligence
     repo: OmniNode-ai/omniintelligence


### PR DESCRIPTION
Part of the org repo registry reconciliation (Wave 2 / C1) — OMN-16312.

repos.yaml described `omnidash` as a "Next.js analytics dashboard". Live `omnidash` is a Vite + React composable widget dashboard; "Next.js analytics dashboard" describes the separate, archived `omnidash-archived` repo. This repo's own README.md and CLAUDE.md already carried the correct wording — repos.yaml was the one stale copy.

Discovered while generating a canonical repository registry page in `knowledge-base` from this file (`repos.yaml` is the org's single machine-read repository manifest per the 2026-08-17 docs consolidation plan §7 C1). Companion PRs:
- knowledge-base#40 — the generated registry page
- OmniNode-ai/.github — regenerates the org profile's Core Repositories table from the same source

No behavior change; single-line metadata correction, `make install` unaffected.